### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "csharp"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Run on Repl.it](https://repl.it/badge/github/kgashok/journal-cli)](https://repl.it/github/kgashok/journal-cli)
 [![Build status](https://img.shields.io/appveyor/ci/refactorsaurusrex/journal-cli?style=for-the-badge)](https://ci.appveyor.com/project/refactorsaurusrex/journal-cli/branch/master) 
 
 [![PowerShell Gallery Version](https://img.shields.io/powershellgallery/v/JournalCli?style=for-the-badge)](https://www.powershellgallery.com/packages/JournalCli) [![PowerShell Gallery](https://img.shields.io/powershellgallery/dt/journalcli?style=for-the-badge&label=Downloads)](https://www.powershellgallery.com/packages/JournalCli) [![MyGet](https://img.shields.io/myget/journal-cli/v/JournalCli?label=Beta&style=for-the-badge)](https://www.myget.org/feed/journal-cli/package/nuget/JournalCli) 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@ashokb/journal-cli).

## Summary
> Please write a summary of what changes are being proposed and why.

## Issues closed or fixed
- Issue one
- Issue two
- etc...

## Required tasks
- [ ] Update Docs
